### PR TITLE
Add missing APP_NAME setting

### DIFF
--- a/mapss/settings.py
+++ b/mapss/settings.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     pass
 
+APP_NAME = "mapss"
 APP_ROOT = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
 ARCHES_APPLICATIONS = ()


### PR DESCRIPTION
`manage.py build_development` failed without it, see 7.x release notes